### PR TITLE
Add validation future date

### DIFF
--- a/bin/aip
+++ b/bin/aip
@@ -31,6 +31,7 @@ __version__ = "1.0.0"
 
 import argparse
 import logging
+import sys
 from datetime import date
 from os import makedirs
 from os import path
@@ -74,7 +75,11 @@ def main():
     logging.basicConfig(level=args.log_level, format=log_fmt)
 
     # Validate input date
-    run_date_day = validate_and_convert_date(args.date)
+    try:
+        run_date_day = validate_and_convert_date(args.date)
+    except ValueError as err:
+        logging.error(err)
+        sys.exit()
 
     # Run Alpha Model
     if args.model in ['Alpha', 'all']:

--- a/lib/aip/utils/date_utils.py
+++ b/lib/aip/utils/date_utils.py
@@ -1,5 +1,5 @@
-import logging
 from datetime import datetime
+from datetime import date
 
 
 def validate_and_convert_date(date_str):
@@ -7,8 +7,10 @@ def validate_and_convert_date(date_str):
     Validates a date string in 'YYYY-MM-DD' format and converts it to a date object.
     """
     try:
-        dateobj = datetime.strptime(date_str, '%Y-%m-%d')
-        return dateobj.date()
-    except ValueError as e:
-        logging.error(f"Invalid date format for '{date_str}', expected YYYY-MM-DD")
-        raise ValueError(f"Invalid date format: {date_str}, expected YYYY-MM-DD") from e
+        dateobj = datetime.strptime(date_str, '%Y-%m-%d').date()
+        date_today = date.today()
+        if dateobj > date_today:
+            raise ValueError(f"The input date '{date_str}' cannot be in the future.")
+        return dateobj
+    except ValueError as err:
+        raise ValueError(f"Invalid date format: {date_str}, expected YYYY-MM-DD") from err

--- a/tests/test_lib_aip_utils_date_utils.py
+++ b/tests/test_lib_aip_utils_date_utils.py
@@ -1,6 +1,7 @@
 import unittest
 import logging
 from datetime import date
+from datetime import timedelta
 from lib.aip.utils.date_utils import validate_and_convert_date
 
 
@@ -47,6 +48,14 @@ class TestValidateAndConvertDate(unittest.TestCase):
     def test_edge_case(self):
         # Test leap years
         self.assertEqual(validate_and_convert_date("2024-02-29"), date(2024, 2, 29))
+
+    def test_future_date(self):
+        # Test future date raises exception
+        future_date = (date.today() + timedelta(days=1)).isoformat()
+
+        with self.assertRaises(ValueError):
+            validate_and_convert_date(future_date)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
# Description

We want to make sure that AIP does not run when a given date is in the future to avoid errors and possible data corruption on the historical knowledge base creation. 

Fixes #45 

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] Added a test to check that a future date raises the exception
- [x] Tested manually with older dates, current dates, and future dates.


# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings