### PR TITLE
Knowledge base rebuild take start and end dates via arguments

### DIFF
--- a/bin/aip
+++ b/bin/aip
@@ -78,43 +78,41 @@ def main():
     log_fmt = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
     logging.basicConfig(level=args.log_level, format=log_fmt)
 
-    if args.rebuild_kb:
-        try:
+    try: 
+        # Rebuild knowledge base
+        if args.rebuild_kb:
             rebuild_date = validate_and_convert_date(args.rebuild_kb)
-        except ValueError as err:
-            logger.error(err)
+            logger.info(f"Rebuilding knowledge base from {rebuild_date} onwards")
+            _rebuild(start_date=rebuild_date, log_level=args.log_level)
             sys.exit()
-        logger.info(f"Rebuilding knowledge base from {rebuild_date} onwards")
-        _rebuild(start_date=rebuild_date, log_level=args.log_level)
-        sys.exit()
 
-    # Validate input date
-    try:
-        run_date_day = validate_and_convert_date(args.date)
+        # Validate input date
+        if args.date: 
+            run_date_day = validate_and_convert_date(args.date)
+
+        logging.info(f"Running {args.model} model(s) for date {run_date_day}.")
+        # Run Alpha Model
+        if args.model in ['Alpha', 'all']:
+            run_model('Alpha', Alpha(), run_date_day, args.log_level)
+
+        # Alpha 7 Model
+        if args.model in ['Alpha7', 'all']:
+            run_model('Alpha7', Alpha7(), run_date_day, args.log_level)
+
+        # Prioritize New Model
+        if args.model in ['Prioritize_New', 'all']:
+            run_model('Prioritize_New', New(), run_date_day, args.log_level)
+
+        # Prioritize Consistent Model
+        if args.model in ['Prioritize_Consistent', 'all']:
+            run_model('Prioritize_Consistent', Consistent(), run_date_day, args.log_level)
+
+        # Prioritize Random Forest Model
+        if args.model in ['Random_Forest', 'all']:
+            run_model('Random_Forest', RandomForest(), run_date_day, args.log_level)
     except ValueError as err:
         logger.error(err)
         sys.exit()
-
-    logging.info(f"Running {args.model} model(s) for date {run_date_day}.")
-    # Run Alpha Model
-    if args.model in ['Alpha', 'all']:
-        run_model('Alpha', Alpha(), run_date_day, args.log_level)
-
-    # Alpha 7 Model
-    if args.model in ['Alpha7', 'all']:
-        run_model('Alpha7', Alpha7(), run_date_day, args.log_level)
-
-    # Prioritize New Model
-    if args.model in ['Prioritize_New', 'all']:
-        run_model('Prioritize_New', New(), run_date_day, args.log_level)
-
-    # Prioritize Consistent Model
-    if args.model in ['Prioritize_Consistent', 'all']:
-        run_model('Prioritize_Consistent', Consistent(), run_date_day, args.log_level)
-
-    # Prioritize Random Forest Model
-    if args.model in ['Random_Forest', 'all']:
-        run_model('Random_Forest', RandomForest(), run_date_day, args.log_level)
 
 if __name__ == '__main__':
     main()

--- a/lib/aip/utils/knowledge_base.py
+++ b/lib/aip/utils/knowledge_base.py
@@ -75,7 +75,7 @@ def _build_knowledge(start, end, log_level=logging.ERROR):
     return last_knowledge
 
 
-def _rebuild(start_date, log_level=logging.ERROR):
+def _rebuild(start_date, end_date=date.today(), log_level=logging.ERROR):
     """
     Wrapper to rebuild the knowledge base from the specified start date to today.
     """
@@ -84,8 +84,9 @@ def _rebuild(start_date, log_level=logging.ERROR):
     logging.basicConfig(level=log_level)
 
     start_time = time.time()
+    logger.info(f"_rebuild - Rebuilding knowledge base from {start_date} to {end_date}")
 
-    _build_knowledge(start=start_date, end=current_date, log_level=log_level)
+    _build_knowledge(start=start_date, end=end_date, log_level=log_level)
 
     logger.debug(f'_rebuild - Rebuilding knowledge base finished in {(time.time() - start_time)/60} minutes')
 

--- a/lib/aip/utils/knowledge_base.py
+++ b/lib/aip/utils/knowledge_base.py
@@ -83,13 +83,11 @@ def _rebuild(start_date, log_level=logging.ERROR):
     logger = logging.getLogger(__name__)
     logging.basicConfig(level=log_level)
 
-    st_time = time.time()
-    current_date = date.today()
-    logger.info(f"_rebuild - Rebuilding knowledge base from {start_date} to {current_date}")
+    start_time = time.time()
 
     _build_knowledge(start=start_date, end=current_date, log_level=log_level)
 
-    logger.info(f'_rebuild - Rebuilding knowledge base finished in {(time.time() - st_time)/60} minutes')
+    logger.debug(f'_rebuild - Rebuilding knowledge base finished in {(time.time() - start_time)/60} minutes')
 
 
 class Knowledgebase():

--- a/lib/aip/utils/knowledge_base.py
+++ b/lib/aip/utils/knowledge_base.py
@@ -84,7 +84,7 @@ def _rebuild(start_date, end_date=date.today(), log_level=logging.ERROR):
     logging.basicConfig(level=log_level)
 
     start_time = time.time()
-    logger.info(f"_rebuild - Rebuilding knowledge base from {start_date} to {end_date}")
+    logger.debug(f"_rebuild - Rebuilding knowledge base from {start_date} to {end_date}")
 
     _build_knowledge(start=start_date, end=end_date, log_level=log_level)
 


### PR DESCRIPTION
# Description

This PR introduces some changes to the Knowledge Base `_rebuild()` function so that it can be called to rebuild the knowledge only between two given dates.

closes #70 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

