### PR TITLE
Add option to run all models between two dates

### DIFF
--- a/bin/aip
+++ b/bin/aip
@@ -73,6 +73,7 @@ def main():
     # Run Models command 
     run_models_parser = subparsers.add_parser("run-models", help="Run models with optional date range.")
     run_models_parser.add_argument('--start-date', type=str, help='The start date for running the models (YYYY-MM-DD). Default is today.', default=str(date.today()))
+    run_models_parser.add_argument('--end-date', type=str, help='The end date for running the models (YYYY-MM-DD). Default is today.', default=str(date.today()))
     run_models_parser.add_argument('--model', type=str, choices=['Alpha', 'Alpha7', 'Prioritize_New', 'Prioritize_Consistent', 'Random_Forest', 'all'], default='all', help='Select AIP model to run. Default is all models.')
 
     # Rebuild KB command
@@ -85,6 +86,12 @@ def main():
     logger = logging.getLogger('aip')
     log_fmt = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
     logging.basicConfig(level=args.log_level, format=log_fmt)
+
+    # If not set, default to today()
+    if not hasattr(args, 'start_date'):
+        args.start_date = date.today().strftime('%Y-%m-%d')
+    if not hasattr(args, 'end_date'):
+        args.end_date = date.today().strftime('%Y-%m-%d')
 
     try: 
         # Validate start_date once not on every command

--- a/bin/aip
+++ b/bin/aip
@@ -33,6 +33,7 @@ import argparse
 import logging
 import sys
 from datetime import date
+from datetime import timedelta
 from os import makedirs
 from os import path
 from aip.data.access import data_path
@@ -109,46 +110,49 @@ def main():
             _rebuild(start_date=aip_start_date, log_level=args.log_level)
             sys.exit()
 
-        logging.info(f"Running {args.model} model(s) for date {aip_start_date}.")
-        # Run Alpha Model
-        if args.model in ['Alpha', 'all']:
-            run_model(aip_model_name='Alpha',
-                      aip_model=Alpha(),
-                      start_date=aip_start_date,
-                      log_level=args.log_level
-                    )
 
-        # Alpha 7 Model
-        if args.model in ['Alpha7', 'all']:
-            run_model(aip_model_name='Alpha7',
-                      aip_model=Alpha7(),
-                      start_date=aip_start_date,
-                      log_level=args.log_level
-                    )
+        while aip_start_date <= aip_end_date:
+            logging.info(f"Running {args.model} model(s) for date {aip_start_date}.")
+            # Run Alpha Model
+            if args.model in ['Alpha', 'all']:
+                run_model(aip_model_name='Alpha',
+                        aip_model=Alpha(),
+                        start_date=aip_start_date,
+                        log_level=args.log_level
+                        )
 
-        # Prioritize New Model
-        if args.model in ['Prioritize_New', 'all']:
-            run_model(aip_model_name='Prioritize_New',
-                      aip_model=New(),
-                      start_date=aip_start_date,
-                      log_level=args.log_level
-                    )
+            # Alpha 7 Model
+            if args.model in ['Alpha7', 'all']:
+                run_model(aip_model_name='Alpha7',
+                        aip_model=Alpha7(),
+                        start_date=aip_start_date,
+                        log_level=args.log_level
+                        )
 
-        # Prioritize Consistent Model
-        if args.model in ['Prioritize_Consistent', 'all']:
-            run_model(aip_model_name='Prioritize_Consistent',
-                      aip_model=Consistent(),
-                      start_date=aip_start_date,
-                      log_level=args.log_level
-                    )
+            # Prioritize New Model
+            if args.model in ['Prioritize_New', 'all']:
+                run_model(aip_model_name='Prioritize_New',
+                        aip_model=New(),
+                        start_date=aip_start_date,
+                        log_level=args.log_level
+                        )
 
-        # Prioritize Random Forest Model
-        if args.model in ['Random_Forest', 'all']:
-            run_model(aip_model_name='Random_Forest',
-                      aip_model=RandomForest(),
-                      start_date=aip_start_date,
-                      log_level=args.log_level
-                    )
+            # Prioritize Consistent Model
+            if args.model in ['Prioritize_Consistent', 'all']:
+                run_model(aip_model_name='Prioritize_Consistent',
+                        aip_model=Consistent(),
+                        start_date=aip_start_date,
+                        log_level=args.log_level
+                        )
+
+            # Prioritize Random Forest Model
+            if args.model in ['Random_Forest', 'all']:
+                run_model(aip_model_name='Random_Forest',
+                        aip_model=RandomForest(),
+                        start_date=aip_start_date,
+                        log_level=args.log_level
+                        )
+            aip_start_date += timedelta(days=1)
 
     except ValueError as err:
         logger.error(err)

--- a/bin/aip
+++ b/bin/aip
@@ -94,12 +94,10 @@ def main():
         args.end_date = date.today().strftime('%Y-%m-%d')
 
     try: 
-        # Validate start_date once not on every command
-        if hasattr(args,'start_date'):
-            aip_start_date = validate_and_convert_date(args.start_date)
-        else:
-            # If not set, default to today()
-            aip_start_date = date.today()
+        # Validate once not on every command
+        aip_start_date = validate_and_convert_date(args.start_date)
+        aip_end_date = validate_and_convert_date(args.end_date)
+        logger.debug(f"AIP will run models from start date {aip_start_date} to end date {aip_end_date}")
 
         # If model is not set, default to today
         if not hasattr(args,'model'):

--- a/bin/aip
+++ b/bin/aip
@@ -107,23 +107,43 @@ def main():
         logging.info(f"Running {args.model} model(s) for date {aip_start_date}.")
         # Run Alpha Model
         if args.model in ['Alpha', 'all']:
-            run_model('Alpha', Alpha(), aip_start_date, args.log_level)
+            run_model(aip_model_name='Alpha',
+                      aip_model=Alpha(),
+                      start_date=aip_start_date,
+                      log_level=args.log_level
+                    )
 
         # Alpha 7 Model
         if args.model in ['Alpha7', 'all']:
-            run_model('Alpha7', Alpha7(), aip_start_date, args.log_level)
+            run_model(aip_model_name='Alpha7',
+                      aip_model=Alpha7(),
+                      start_date=aip_start_date,
+                      log_level=args.log_level
+                    )
 
         # Prioritize New Model
         if args.model in ['Prioritize_New', 'all']:
-            run_model('Prioritize_New', New(), aip_start_date, args.log_level)
+            run_model(aip_model_name='Prioritize_New',
+                      aip_model=New(),
+                      start_date=aip_start_date,
+                      log_level=args.log_level
+                    )
 
         # Prioritize Consistent Model
         if args.model in ['Prioritize_Consistent', 'all']:
-            run_model('Prioritize_Consistent', Consistent(), aip_start_date, args.log_level)
+            run_model(aip_model_name='Prioritize_Consistent',
+                      aip_model=Consistent(),
+                      start_date=aip_start_date,
+                      log_level=args.log_level
+                    )
 
         # Prioritize Random Forest Model
         if args.model in ['Random_Forest', 'all']:
-            run_model('Random_Forest', RandomForest(), aip_start_date, args.log_level)
+            run_model(aip_model_name='Random_Forest',
+                      aip_model=RandomForest(),
+                      start_date=aip_start_date,
+                      log_level=args.log_level
+                    )
 
     except ValueError as err:
         logger.error(err)

--- a/bin/aip
+++ b/bin/aip
@@ -45,7 +45,7 @@ from aip.utils.date_utils import validate_and_convert_date
 from aip.utils.knowledge_base import _rebuild
 
 
-def run_model(aip_model_name, aip_model, date_day, log_level=logging.ERROR):
+def run_model(aip_model_name, aip_model, start_date, log_level=logging.ERROR):
     """
     Run a given model with exception handling
     """
@@ -56,8 +56,8 @@ def run_model(aip_model_name, aip_model, date_day, log_level=logging.ERROR):
         makedirs(model_output_dir)
 
     try:
-        blocklist = aip_model.run(date_day)
-        blocklist.to_csv(path.join(model_output_dir, f'AIP-{aip_model_name}-{str(date_day)}.csv.gz'), index=False, compression='gzip')
+        blocklist = aip_model.run(start_date)
+        blocklist.to_csv(path.join(model_output_dir, f'AIP-{aip_model_name}-{str(start_date)}.csv.gz'), index=False, compression='gzip')
         logging.info(f"{aip_model_name} model completed successfully.")
     except Exception as err:
         logging.error(f"Error running {aip_model_name} model: {err}")


### PR DESCRIPTION
# Description

This PR introduces an additional '--end-date' parameter and adjusts how AIP runs. In sum, this allows anyone to run AIP between two dates, enabling the use of AIP with custom datasets that are dated in the past.

Fixes #68 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] AIP was tested with with multiple options: by default without dates, using run-models, with start date and not end date, with start date in the future and end-date in the past, etc.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

# Changes to the documentation

- [x] I have made corresponding changes to the documentation
