### PR TITLE
Validate data and raise exception

### DIFF
--- a/lib/aip/models/alpha.py
+++ b/lib/aip/models/alpha.py
@@ -46,11 +46,14 @@ class Alpha(BaseModel):
         # Get all the attackers IPs
         attacks = get_attacks(start, end, usecols=['orig'])
         attacks = pd.concat(attacks).drop_duplicates()
-        attacks = attacks.rename(columns={'orig':'ip'})
+        if not attacks.empty:
+            attacks = attacks.rename(columns={'orig':'ip'})
 
-        self.blocklist = attacks
+            self.blocklist = attacks
 
-        # Remove IPs from do_not_block_these_ips.csv
-        self.sanitize()
+            # Remove IPs from do_not_block_these_ips.csv
+            self.sanitize()
 
-        return self.blocklist
+            return self.blocklist
+        else:
+            raise ValueError("Please check data availability and try again.")


### PR DESCRIPTION
# Description

This PR fixes a bug in which the Alpha and Alpha7 models will report success even when there's no data available to run the models.
- The Alpha model was modified to validate that the attack cache is not empty before attempting to build the blocklist.
- An exception is now raised if the attack cache is empty so the run_model will report the exception instead of success.

Fixes #66 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Tested locally with many start and end date combinations, including the example reported in #66 

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

# Changes to the documentation

- [x] I have made corresponding changes to the documentation
